### PR TITLE
feat: add publishing actions and rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Release Packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: npm ci
+      - run: npm run build
+      - name: Upload Artifact
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/interfaces/dictionary/index.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "directus-dictionary",
+  "name": "directus-extension-dictionary-test",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "directus-extension-dictionary-test",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -157,12 +158,8 @@
         "@vue/component-compiler-utils": "^3.0.0",
         "clean-css": "^4.1.11",
         "hash-sum": "^1.0.2",
-        "less": "^3.9.0",
         "postcss-modules-sync": "^1.0.0",
-        "pug": "^2.0.3",
-        "sass": "^1.18.0",
-        "source-map": "0.6.*",
-        "stylus": "^0.54.5"
+        "source-map": "0.6.*"
       },
       "optionalDependencies": {
         "less": "^3.9.0",
@@ -187,7 +184,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.14",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -723,7 +719,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1949,9 +1944,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2014,13 +2006,6 @@
       "optional": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "native-request": "^1.0.5",
-        "source-map": "~0.6.0",
         "tslib": "^1.10.0"
       },
       "bin": {
@@ -3395,9 +3380,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.40.0.tgz",
       "integrity": "sha512-WiOGAPbXoHu+TOz6hyYUxIksOwsY/21TRWoO593jgYt8mvYafYqQl+axaA8y1z2HFazNUUrsMSjahV2A6/2R9A==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.1"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -3459,7 +3441,6 @@
       "integrity": "sha512-IWREkMDJLJbS3aa1aakYYdJc3yPUb4BBrmK8hgThmtr7hWevBvCZ3b0SXm/Tgx53RxV9q1Btf4hD7nczJiDsfw==",
       "dev": true,
       "dependencies": {
-        "node-sass": "4",
         "rollup-pluginutils": "2"
       },
       "optionalDependencies": {
@@ -4046,7 +4027,6 @@
       "optional": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "name": "directus-dictionary",
+  "name": "directus-extension-dictionary",
   "author": "George Chelebiev <george@forkforkfork.com>",
   "license": "MIT",
   "keywords": [
@@ -12,6 +12,16 @@
     "type": "git",
     "url": "https://github.com/georgexchelebiev/directus-dictionary"
   },
+  "directus:extension": {
+    "type": "interface",
+    "path": "dist/interfaces/dictionary/index.js",
+    "source": "src/interfaces/dictonary/index.ts",
+    "host": "^v9.9.0",
+    "hidden": false
+  },
+  "files": [
+    "dist"
+  ],
   "homepage": "https://github.com/georgexchelebiev/directus-dictionary#readme",
   "scripts": {
     "build": "rollup -c"


### PR DESCRIPTION
closes #3 

This PR would add automatic NPM publishing and GitHub artifact uploads whenever creating a new release (for example through the GitHub web interface).

Here we also update the package.json name-field to a `directus-extension`-prefix, so that this could be automatically installed to directus with `npm install` (https://github.com/directus/directus/discussions/12408). Maybe even a rename to `directus-extension-dictionary-interface` instead of this PRs `directus-extension-dictionary` could be used?

Steps needed for this to work:
1. Create an NPM account
2. Create an automation access token (https://docs.npmjs.com/creating-and-viewing-access-tokens)
3. Add a secret to your repo  named `NPM_TOKEN` (https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-codespaces#adding-secrets-for-a-repository)
4. Merge this PR
5. (Bump version?)
6. Create a new release
7. `npm install directus-extension-dictionary` :tada: 

When trying this out (with npm package `directus-extension-dictionary-test`) I noticed that the interface doesn't seem to work like the GIF when setting it up (on Directus@9.11.1 at least), but as I don't know how to fix that I hope this PR might motivate you or someone to fix it at some point, would be really great for generic i18n strings for my usecases :)